### PR TITLE
Add toast notification for cart interactions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "react-redux": "^9.1.2",
         "react-simple-star-rating": "^5.1.7",
         "redux-persist": "^6.0.0",
+        "sonner": "^2.0.7",
         "tailwind-merge": "^2.5.2",
         "tailwindcss-animate": "^1.0.7",
         "usehooks-ts": "^3.1.0",
@@ -2509,6 +2510,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/sonner": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
+      "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/source-map-js": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "react-redux": "^9.1.2",
     "react-simple-star-rating": "^5.1.7",
     "redux-persist": "^6.0.0",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^2.5.2",
     "tailwindcss-animate": "^1.0.7",
     "usehooks-ts": "^3.1.0",

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -5,6 +5,7 @@ import { Provider } from "react-redux";
 import { makeStore } from "../lib/store";
 import { PersistGate } from "redux-persist/integration/react";
 import SpinnerbLoader from "@/components/ui/SpinnerbLoader";
+import Toaster from "@/components/ui/toaster";
 
 type Props = {
   children: React.ReactNode;
@@ -23,7 +24,10 @@ const Providers = ({ children }: Props) => {
         }
         persistor={persistor}
       >
-        {children}
+        <>
+          {children}
+          <Toaster richColors closeButton expand={false} />
+        </>
       </PersistGate>
     </Provider>
   );

--- a/src/components/product-page/Header/AddToCartBtn.tsx
+++ b/src/components/product-page/Header/AddToCartBtn.tsx
@@ -5,6 +5,7 @@ import { useAppDispatch, useAppSelector } from "@/lib/hooks/redux";
 import { RootState } from "@/lib/store";
 import { Product } from "@/types/product.types";
 import React from "react";
+import { toast } from "sonner";
 
 const AddToCartBtn = ({ data }: { data: Product & { quantity: number } }) => {
   const dispatch = useAppDispatch();
@@ -16,7 +17,7 @@ const AddToCartBtn = ({ data }: { data: Product & { quantity: number } }) => {
     <button
       type="button"
       className="bg-black w-full ml-3 sm:ml-5 rounded-full h-11 md:h-[52px] text-sm sm:text-base text-white hover:bg-black/80 transition-all"
-      onClick={() =>
+      onClick={() => {
         dispatch(
           addToCart({
             id: data.id,
@@ -27,8 +28,12 @@ const AddToCartBtn = ({ data }: { data: Product & { quantity: number } }) => {
             discount: data.discount,
             quantity: data.quantity,
           })
-        )
-      }
+        );
+
+        toast.success("Added to cart", {
+          description: `${data.title} (${colorSelection.name} / ${sizeSelection}) was added to your bag.`,
+        });
+      }}
     >
       Add to Cart
     </button>

--- a/src/components/ui/toaster.tsx
+++ b/src/components/ui/toaster.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { Toaster as SonnerToaster } from "sonner";
+import type { ComponentProps } from "react";
+
+type ToasterProps = ComponentProps<typeof SonnerToaster>;
+
+export const Toaster = ({ ...props }: ToasterProps) => {
+  return (
+    <SonnerToaster
+      theme="light"
+      position="top-right"
+      toastOptions={{
+        classNames: {
+          toast:
+            "bg-white border border-zinc-200 shadow-lg rounded-xl px-4 py-3 text-sm text-zinc-900",
+          description: "text-zinc-500",
+          actionButton:
+            "bg-black text-white rounded-full px-3 py-1 text-sm font-medium hover:bg-black/80",
+          cancelButton:
+            "bg-transparent text-zinc-500 hover:text-zinc-900 hover:bg-zinc-100",
+        },
+      }}
+      {...props}
+    />
+  );
+};
+
+export default Toaster;


### PR DESCRIPTION
## Summary
- add a Sonner-based toaster component and wire it into the persisted Redux provider tree
- trigger a styled success toast whenever a user adds a product to their cart
- style toast notifications to match the app’s visual language

## Testing
- npm run lint *(fails: command opens interactive ESLint configuration prompt in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d501968ed48322b9201a84df039103