### PR TITLE
Implement functional filtering on shop page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -16,6 +16,10 @@ export const newArrivalsData: Product[] = [
       percentage: 0,
     },
     rating: 4.5,
+    category: "t-shirts",
+    style: "casual",
+    colors: ["green", "white"],
+    sizes: ["Small", "Medium", "Large", "X-Large"],
   },
   {
     id: 2,
@@ -28,6 +32,10 @@ export const newArrivalsData: Product[] = [
       percentage: 20,
     },
     rating: 3.5,
+    category: "jeans",
+    style: "casual",
+    colors: ["blue", "black"],
+    sizes: ["Small", "Medium", "Large", "X-Large", "XX-Large"],
   },
   {
     id: 3,
@@ -40,6 +48,10 @@ export const newArrivalsData: Product[] = [
       percentage: 0,
     },
     rating: 4.5,
+    category: "shirts",
+    style: "formal",
+    colors: ["red", "black", "white"],
+    sizes: ["Small", "Medium", "Large", "X-Large"],
   },
   {
     id: 4,
@@ -52,6 +64,10 @@ export const newArrivalsData: Product[] = [
       percentage: 30,
     },
     rating: 4.5,
+    category: "t-shirts",
+    style: "casual",
+    colors: ["orange", "white", "black"],
+    sizes: ["Small", "Medium", "Large"],
   },
 ];
 
@@ -67,6 +83,10 @@ export const topSellingData: Product[] = [
       percentage: 20,
     },
     rating: 5.0,
+    category: "shirts",
+    style: "formal",
+    colors: ["blue", "white"],
+    sizes: ["Medium", "Large", "X-Large"],
   },
   {
     id: 6,
@@ -79,6 +99,10 @@ export const topSellingData: Product[] = [
       percentage: 0,
     },
     rating: 4.0,
+    category: "t-shirts",
+    style: "casual",
+    colors: ["black", "yellow"],
+    sizes: ["Small", "Medium", "Large", "X-Large"],
   },
   {
     id: 7,
@@ -91,6 +115,10 @@ export const topSellingData: Product[] = [
       percentage: 0,
     },
     rating: 3.0,
+    category: "shorts",
+    style: "gym",
+    colors: ["green", "black"],
+    sizes: ["Small", "Medium", "Large"],
   },
   {
     id: 8,
@@ -103,6 +131,10 @@ export const topSellingData: Product[] = [
       percentage: 0,
     },
     rating: 4.5,
+    category: "jeans",
+    style: "casual",
+    colors: ["blue", "black", "white"],
+    sizes: ["Small", "Medium", "Large", "X-Large", "XX-Large"],
   },
 ];
 
@@ -118,6 +150,10 @@ export const relatedProductData: Product[] = [
       percentage: 20,
     },
     rating: 4.0,
+    category: "shirts",
+    style: "casual",
+    colors: ["black", "white"],
+    sizes: ["Small", "Medium", "Large", "X-Large"],
   },
   {
     id: 13,
@@ -130,6 +166,10 @@ export const relatedProductData: Product[] = [
       percentage: 0,
     },
     rating: 3.5,
+    category: "t-shirts",
+    style: "party",
+    colors: ["pink", "purple", "white"],
+    sizes: ["Small", "Medium", "Large"],
   },
   {
     id: 14,
@@ -142,6 +182,10 @@ export const relatedProductData: Product[] = [
       percentage: 0,
     },
     rating: 4.5,
+    category: "shirts",
+    style: "formal",
+    colors: ["yellow", "white"],
+    sizes: ["Medium", "Large", "X-Large"],
   },
   {
     id: 15,
@@ -154,6 +198,10 @@ export const relatedProductData: Product[] = [
       percentage: 30,
     },
     rating: 5.0,
+    category: "t-shirts",
+    style: "casual",
+    colors: ["black", "white"],
+    sizes: ["Small", "Medium", "Large", "X-Large"],
   },
 ];
 

--- a/src/components/shop-page/filters/CategoriesSection.tsx
+++ b/src/components/shop-page/filters/CategoriesSection.tsx
@@ -1,46 +1,51 @@
-import Link from "next/link";
+"use client";
+
 import React from "react";
 import { MdKeyboardArrowRight } from "react-icons/md";
+import { cn } from "@/lib/utils";
 
 type Category = {
-  title: string;
-  slug: string;
+  label: string;
+  value: string;
 };
 
-const categoriesData: Category[] = [
-  {
-    title: "T-shirts",
-    slug: "/shop?category=t-shirts",
-  },
-  {
-    title: "Shorts",
-    slug: "/shop?category=shorts",
-  },
-  {
-    title: "Shirts",
-    slug: "/shop?category=shirts",
-  },
-  {
-    title: "Hoodie",
-    slug: "/shop?category=hoodie",
-  },
-  {
-    title: "Jeans",
-    slug: "/shop?category=jeans",
-  },
-];
+type CategoriesSectionProps = {
+  categories: Category[];
+  selectedCategory: string | null;
+  onSelectCategory: (value: string | null) => void;
+};
 
-const CategoriesSection = () => {
+const CategoriesSection = ({
+  categories,
+  selectedCategory,
+  onSelectCategory,
+}: CategoriesSectionProps) => {
+  const handleSelect = (value: string) => {
+    if (selectedCategory === value) {
+      onSelectCategory(null);
+      return;
+    }
+
+    onSelectCategory(value);
+  };
+
   return (
     <div className="flex flex-col space-y-0.5 text-black/60">
-      {categoriesData.map((category, idx) => (
-        <Link
-          key={idx}
-          href={category.slug}
-          className="flex items-center justify-between py-2"
+      {categories.map((category) => (
+        <button
+          key={category.value}
+          type="button"
+          onClick={() => handleSelect(category.value)}
+          className={cn(
+            "flex items-center justify-between py-2 text-left transition-colors",
+            selectedCategory === category.value
+              ? "text-black font-medium"
+              : "hover:text-black"
+          )}
         >
-          {category.title} <MdKeyboardArrowRight />
-        </Link>
+          {category.label}
+          <MdKeyboardArrowRight />
+        </button>
       ))}
     </div>
   );

--- a/src/components/shop-page/filters/ColorsSection.tsx
+++ b/src/components/shop-page/filters/ColorsSection.tsx
@@ -10,8 +10,39 @@ import {
 import { IoMdCheckmark } from "react-icons/io";
 import { cn } from "@/lib/utils";
 
-const ColorsSection = () => {
-  const [selected, setSelected] = useState<string>("bg-green-600");
+type ColorOption = {
+  value: string;
+  className: string;
+};
+
+type ColorsSectionProps = {
+  colors: ColorOption[];
+  selectedColors: string[];
+  onSelectColors: (colors: string[]) => void;
+};
+
+const ColorsSection = ({
+  colors,
+  selectedColors,
+  onSelectColors,
+}: ColorsSectionProps) => {
+  const [selected, setSelected] = useState<string[]>(selectedColors);
+
+  const toggleColor = (value: string) => {
+    setSelected((prev) => {
+      const exists = prev.includes(value);
+      const next = exists
+        ? prev.filter((color) => color !== value)
+        : [...prev, value];
+
+      onSelectColors(next);
+      return next;
+    });
+  };
+
+  React.useEffect(() => {
+    setSelected(selectedColors);
+  }, [selectedColors]);
 
   return (
     <Accordion type="single" collapsible defaultValue="filter-colors">
@@ -21,32 +52,28 @@ const ColorsSection = () => {
         </AccordionTrigger>
         <AccordionContent className="pt-4 pb-0">
           <div className="flex space-2.5 flex-wrap md:grid grid-cols-5 gap-2.5">
-            {[
-              "bg-green-600",
-              "bg-red-600",
-              "bg-yellow-300",
-              "bg-orange-600",
-              "bg-cyan-400",
-              "bg-blue-600",
-              "bg-purple-600",
-              "bg-pink-600",
-              "bg-white",
-              "bg-black",
-            ].map((color, index) => (
-              <button
-                key={index}
-                type="button"
-                className={cn([
-                  color,
-                  "rounded-full w-9 sm:w-10 h-9 sm:h-10 flex items-center justify-center border border-black/20",
-                ])}
-                onClick={() => setSelected(color)}
-              >
-                {selected === color && (
-                  <IoMdCheckmark className="text-base text-white" />
-                )}
-              </button>
-            ))}
+            {colors.map((color) => {
+              const isSelected = selected.includes(color.value);
+              const checkmarkClass = color.value === "white" ? "text-black" : "text-white";
+
+              return (
+                <button
+                  key={color.value}
+                  type="button"
+                  className={cn([
+                    color.className,
+                    "rounded-full w-9 sm:w-10 h-9 sm:h-10 flex items-center justify-center border border-black/20",
+                    isSelected && "ring-2 ring-offset-2 ring-black",
+                  ])}
+                  onClick={() => toggleColor(color.value)}
+                  aria-pressed={isSelected}
+                >
+                  {isSelected && (
+                    <IoMdCheckmark className={cn("text-base", checkmarkClass)} />
+                  )}
+                </button>
+              );
+            })}
           </div>
         </AccordionContent>
       </AccordionItem>

--- a/src/components/shop-page/filters/DressStyleSection.tsx
+++ b/src/components/shop-page/filters/DressStyleSection.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React from "react";
 import {
   Accordion,
@@ -5,34 +7,34 @@ import {
   AccordionItem,
   AccordionTrigger,
 } from "@/components/ui/accordion";
-import Link from "next/link";
 import { MdKeyboardArrowRight } from "react-icons/md";
+import { cn } from "@/lib/utils";
 
 type DressStyle = {
-  title: string;
-  slug: string;
+  label: string;
+  value: string;
 };
 
-const dressStylesData: DressStyle[] = [
-  {
-    title: "Casual",
-    slug: "/shop?style=casual",
-  },
-  {
-    title: "Formal",
-    slug: "/shop?style=formal",
-  },
-  {
-    title: "Party",
-    slug: "/shop?style=party",
-  },
-  {
-    title: "Gym",
-    slug: "/shop?style=gym",
-  },
-];
+type DressStyleSectionProps = {
+  styles: DressStyle[];
+  selectedStyles: string[];
+  onSelectStyles: (styles: string[]) => void;
+};
 
-const DressStyleSection = () => {
+const DressStyleSection = ({
+  styles,
+  selectedStyles,
+  onSelectStyles,
+}: DressStyleSectionProps) => {
+  const toggleStyle = (value: string) => {
+    const exists = selectedStyles.includes(value);
+    const next = exists
+      ? selectedStyles.filter((style) => style !== value)
+      : [...selectedStyles, value];
+
+    onSelectStyles(next);
+  };
+
   return (
     <Accordion type="single" collapsible defaultValue="filter-style">
       <AccordionItem value="filter-style" className="border-none">
@@ -41,15 +43,25 @@ const DressStyleSection = () => {
         </AccordionTrigger>
         <AccordionContent className="pt-4 pb-0">
           <div className="flex flex-col text-black/60 space-y-0.5">
-            {dressStylesData.map((dStyle, idx) => (
-              <Link
-                key={idx}
-                href={dStyle.slug}
-                className="flex items-center justify-between py-2"
-              >
-                {dStyle.title} <MdKeyboardArrowRight />
-              </Link>
-            ))}
+            {styles.map((style) => {
+              const isSelected = selectedStyles.includes(style.value);
+
+              return (
+                <button
+                  key={style.value}
+                  type="button"
+                  onClick={() => toggleStyle(style.value)}
+                  className={cn(
+                    "flex items-center justify-between py-2 text-left transition-colors",
+                    isSelected ? "text-black font-medium" : "hover:text-black"
+                  )}
+                  aria-pressed={isSelected}
+                >
+                  {style.label}
+                  <MdKeyboardArrowRight />
+                </button>
+              );
+            })}
           </div>
         </AccordionContent>
       </AccordionItem>

--- a/src/components/shop-page/filters/MobileFilters.tsx
+++ b/src/components/shop-page/filters/MobileFilters.tsx
@@ -1,4 +1,6 @@
-import React from "react";
+"use client";
+
+import React, { useState } from "react";
 import {
   Drawer,
   DrawerContent,
@@ -9,34 +11,44 @@ import {
 } from "@/components/ui/drawer";
 import { FiSliders } from "react-icons/fi";
 import Filters from ".";
+import { ShopFiltersState } from "@/types/filter.types";
 
-const MobileFilters = () => {
+type MobileFiltersProps = {
+  filters: ShopFiltersState;
+  onFiltersChange: (filters: ShopFiltersState) => void;
+};
+
+const MobileFilters = ({ filters, onFiltersChange }: MobileFiltersProps) => {
+  const [open, setOpen] = useState(false);
+
   return (
-    <>
-      <Drawer>
-        <DrawerTrigger asChild>
-          <button
-            type="button"
-            className="h-8 w-8 rounded-full bg-[#F0F0F0] text-black p-1 md:hidden"
-          >
-            <FiSliders className="text-base mx-auto" />
-          </button>
-        </DrawerTrigger>
-        <DrawerContent className="max-h-[90%]">
-          <DrawerHeader>
-            <div className="flex items-center justify-between">
-              <span className="font-bold text-black text-xl">Filters</span>
-              <FiSliders className="text-2xl text-black/40" />
-            </div>
-            <DrawerTitle className="hidden">filters</DrawerTitle>
-            <DrawerDescription className="hidden">filters</DrawerDescription>
-          </DrawerHeader>
-          <div className="max-h-[90%] overflow-y-auto w-full px-5 md:px-6 py-5 space-y-5 md:space-y-6">
-            <Filters />
+    <Drawer open={open} onOpenChange={setOpen}>
+      <DrawerTrigger asChild>
+        <button
+          type="button"
+          className="h-8 w-8 rounded-full bg-[#F0F0F0] text-black p-1 md:hidden"
+        >
+          <FiSliders className="text-base mx-auto" />
+        </button>
+      </DrawerTrigger>
+      <DrawerContent className="max-h-[90%]">
+        <DrawerHeader>
+          <div className="flex items-center justify-between">
+            <span className="font-bold text-black text-xl">Filters</span>
+            <FiSliders className="text-2xl text-black/40" />
           </div>
-        </DrawerContent>
-      </Drawer>
-    </>
+          <DrawerTitle className="hidden">filters</DrawerTitle>
+          <DrawerDescription className="hidden">filters</DrawerDescription>
+        </DrawerHeader>
+        <div className="max-h-[90%] overflow-y-auto w-full px-5 md:px-6 py-5 space-y-5 md:space-y-6">
+          <Filters
+            filters={filters}
+            onFiltersChange={onFiltersChange}
+            onApply={() => setOpen(false)}
+          />
+        </div>
+      </DrawerContent>
+    </Drawer>
   );
 };
 

--- a/src/components/shop-page/filters/PriceSection.tsx
+++ b/src/components/shop-page/filters/PriceSection.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React from "react";
 import {
   Accordion,
@@ -7,7 +9,12 @@ import {
 } from "@/components/ui/accordion";
 import { Slider } from "@/components/ui/slider";
 
-const PriceSection = () => {
+type PriceSectionProps = {
+  value: [number, number];
+  onValueChange: (value: [number, number]) => void;
+};
+
+const PriceSection = ({ value, onValueChange }: PriceSectionProps) => {
   return (
     <Accordion type="single" collapsible defaultValue="filter-price">
       <AccordionItem value="filter-price" className="border-none">
@@ -16,13 +23,17 @@ const PriceSection = () => {
         </AccordionTrigger>
         <AccordionContent className="pt-4" contentClassName="overflow-visible">
           <Slider
-            defaultValue={[50, 200]}
+            value={value}
             min={0}
             max={250}
             step={1}
             label="$"
+            onValueChange={onValueChange}
           />
-          <div className="mb-3" />
+          <div className="flex items-center justify-between text-sm text-black/60 mt-4">
+            <span>${value[0]}</span>
+            <span>${value[1]}</span>
+          </div>
         </AccordionContent>
       </AccordionItem>
     </Accordion>

--- a/src/components/shop-page/filters/SizeSection.tsx
+++ b/src/components/shop-page/filters/SizeSection.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState } from "react";
+import React from "react";
 import {
   Accordion,
   AccordionContent,
@@ -9,8 +9,25 @@ import {
 } from "@/components/ui/accordion";
 import { cn } from "@/lib/utils";
 
-const SizeSection = () => {
-  const [selected, setSelected] = useState<string>("Large");
+type SizeSectionProps = {
+  sizes: string[];
+  selectedSizes: string[];
+  onSelectSizes: (sizes: string[]) => void;
+};
+
+const SizeSection = ({
+  sizes,
+  selectedSizes,
+  onSelectSizes,
+}: SizeSectionProps) => {
+  const toggleSize = (value: string) => {
+    const exists = selectedSizes.includes(value);
+    const next = exists
+      ? selectedSizes.filter((size) => size !== value)
+      : [...selectedSizes, value];
+
+    onSelectSizes(next);
+  };
 
   return (
     <Accordion type="single" collapsible defaultValue="filter-size">
@@ -20,29 +37,24 @@ const SizeSection = () => {
         </AccordionTrigger>
         <AccordionContent className="pt-4 pb-0">
           <div className="flex items-center flex-wrap">
-            {[
-              "XX-Small",
-              "X-Small",
-              "Small",
-              "Medium",
-              "Large",
-              "X-Large",
-              "XX-Large",
-              "3X-Large",
-              "4X-Large",
-            ].map((size, index) => (
-              <button
-                key={index}
-                type="button"
-                className={cn([
-                  "bg-[#F0F0F0] m-1 flex items-center justify-center px-5 py-2.5 text-sm rounded-full max-h-[39px]",
-                  selected === size && "bg-black font-medium text-white",
-                ])}
-                onClick={() => setSelected(size)}
-              >
-                {size}
-              </button>
-            ))}
+            {sizes.map((size) => {
+              const isSelected = selectedSizes.includes(size);
+
+              return (
+                <button
+                  key={size}
+                  type="button"
+                  className={cn([
+                    "bg-[#F0F0F0] m-1 flex items-center justify-center px-5 py-2.5 text-sm rounded-full max-h-[39px] transition-colors",
+                    isSelected && "bg-black font-medium text-white",
+                  ])}
+                  onClick={() => toggleSize(size)}
+                  aria-pressed={isSelected}
+                >
+                  {size}
+                </button>
+              );
+            })}
           </div>
         </AccordionContent>
       </AccordionItem>

--- a/src/components/shop-page/filters/index.tsx
+++ b/src/components/shop-page/filters/index.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React from "react";
 import CategoriesSection from "@/components/shop-page/filters/CategoriesSection";
 import ColorsSection from "@/components/shop-page/filters/ColorsSection";
@@ -5,23 +7,125 @@ import DressStyleSection from "@/components/shop-page/filters/DressStyleSection"
 import PriceSection from "@/components/shop-page/filters/PriceSection";
 import SizeSection from "@/components/shop-page/filters/SizeSection";
 import { Button } from "@/components/ui/button";
+import { ShopFiltersState } from "@/types/filter.types";
 
-const Filters = () => {
+type FiltersProps = {
+  filters: ShopFiltersState;
+  onFiltersChange: (filters: ShopFiltersState) => void;
+  onApply?: () => void;
+};
+
+const categories = [
+  { label: "T-shirts", value: "t-shirts" },
+  { label: "Shorts", value: "shorts" },
+  { label: "Shirts", value: "shirts" },
+  { label: "Hoodie", value: "hoodie" },
+  { label: "Jeans", value: "jeans" },
+];
+
+const dressStyles = [
+  { label: "Casual", value: "casual" },
+  { label: "Formal", value: "formal" },
+  { label: "Party", value: "party" },
+  { label: "Gym", value: "gym" },
+];
+
+const colorOptions = [
+  { value: "green", className: "bg-green-600" },
+  { value: "red", className: "bg-red-600" },
+  { value: "yellow", className: "bg-yellow-300" },
+  { value: "orange", className: "bg-orange-600" },
+  { value: "cyan", className: "bg-cyan-400" },
+  { value: "blue", className: "bg-blue-600" },
+  { value: "purple", className: "bg-purple-600" },
+  { value: "pink", className: "bg-pink-600" },
+  { value: "white", className: "bg-white" },
+  { value: "black", className: "bg-black" },
+];
+
+const sizeOptions = [
+  "XX-Small",
+  "X-Small",
+  "Small",
+  "Medium",
+  "Large",
+  "X-Large",
+  "XX-Large",
+  "3X-Large",
+  "4X-Large",
+];
+
+const Filters = ({ filters, onFiltersChange, onApply }: FiltersProps) => {
+  const handleCategoryChange = (value: string | null) => {
+    onFiltersChange({
+      ...filters,
+      category: value,
+    });
+  };
+
+  const handlePriceChange = (value: [number, number]) => {
+    onFiltersChange({
+      ...filters,
+      priceRange: value,
+    });
+  };
+
+  const handleColorChange = (value: string[]) => {
+    onFiltersChange({
+      ...filters,
+      colors: value,
+    });
+  };
+
+  const handleSizeChange = (value: string[]) => {
+    onFiltersChange({
+      ...filters,
+      sizes: value,
+    });
+  };
+
+  const handleStyleChange = (value: string[]) => {
+    onFiltersChange({
+      ...filters,
+      styles: value,
+    });
+  };
+
   return (
     <>
       <hr className="border-t-black/10" />
-      <CategoriesSection />
+      <CategoriesSection
+        categories={categories}
+        selectedCategory={filters.category}
+        onSelectCategory={handleCategoryChange}
+      />
       <hr className="border-t-black/10" />
-      <PriceSection />
+      <PriceSection
+        value={filters.priceRange}
+        onValueChange={handlePriceChange}
+      />
       <hr className="border-t-black/10" />
-      <ColorsSection />
+      <ColorsSection
+        colors={colorOptions}
+        selectedColors={filters.colors}
+        onSelectColors={handleColorChange}
+      />
       <hr className="border-t-black/10" />
-      <SizeSection />
+      <SizeSection
+        sizes={sizeOptions}
+        selectedSizes={filters.sizes}
+        onSelectSizes={handleSizeChange}
+      />
       <hr className="border-t-black/10" />
-      <DressStyleSection />
+      <DressStyleSection
+        styles={dressStyles}
+        selectedStyles={filters.styles}
+        onSelectStyles={handleStyleChange}
+      />
       <Button
         type="button"
         className="bg-black w-full rounded-full text-sm font-medium py-4 h-12"
+        onClick={() => onApply?.()}
       >
         Apply Filter
       </Button>

--- a/src/components/ui/slider.tsx
+++ b/src/components/ui/slider.tsx
@@ -5,12 +5,17 @@ import * as SliderPrimitive from "@radix-ui/react-slider";
 import { cn } from "@/lib/utils";
 
 interface SliderProps
-  extends React.ComponentPropsWithoutRef<typeof SliderPrimitive.Root> {
+  extends Omit<
+    React.ComponentPropsWithoutRef<typeof SliderPrimitive.Root>,
+    "value" | "onValueChange" | "defaultValue"
+  > {
   min: number;
   max: number;
   step?: number;
   defaultValue?: [number, number];
+  value?: [number, number];
   label?: string;
+  onValueChange?: (value: [number, number]) => void;
 }
 
 const Slider = React.forwardRef<
@@ -18,21 +23,30 @@ const Slider = React.forwardRef<
   SliderProps
 >(
   (
-    {
-      className,
-      min,
-      max,
-      step = 1,
-      defaultValue = [min, max],
-      label,
-      ...props
-    },
+    { className, min, max, step = 1, defaultValue = [min, max], value, label, onValueChange, ...props },
     ref
   ) => {
-    const [values, setValues] = React.useState<[number, number]>(defaultValue);
+    const [values, setValues] = React.useState<[number, number]>(
+      value ?? defaultValue
+    );
+
+    React.useEffect(() => {
+      if (value) {
+        setValues(value);
+      }
+    }, [value]);
 
     const handleValueChange = (newValues: number[]) => {
-      setValues([newValues[0], newValues[1]]);
+      const nextValues: [number, number] = [
+        newValues[0],
+        newValues[1] ?? newValues[0],
+      ];
+
+      if (!value) {
+        setValues(nextValues);
+      }
+
+      onValueChange?.(nextValues);
     };
 
     return (
@@ -46,7 +60,7 @@ const Slider = React.forwardRef<
           min={min}
           max={max}
           step={step}
-          value={values}
+          value={value ?? values}
           onValueChange={handleValueChange}
           {...props}
         >

--- a/src/types/filter.types.ts
+++ b/src/types/filter.types.ts
@@ -1,0 +1,15 @@
+export type ShopFiltersState = {
+  category: string | null;
+  styles: string[];
+  colors: string[];
+  sizes: string[];
+  priceRange: [number, number];
+};
+
+export const defaultShopFiltersState: ShopFiltersState = {
+  category: null,
+  styles: [],
+  colors: [],
+  sizes: [],
+  priceRange: [0, 250],
+};

--- a/src/types/product.types.ts
+++ b/src/types/product.types.ts
@@ -11,4 +11,8 @@ export type Product = {
   price: number;
   discount: Discount;
   rating: number;
+  category: string;
+  style: string;
+  colors: string[];
+  sizes: string[];
 };


### PR DESCRIPTION
## Summary
- convert the shop page to a client component that manages filter and sort state across the available product catalog
- extend product data and types with category, style, color, and size metadata to support filtering
- refactor the filter UI, including controlled accordion sections and slider updates, so selections immediately update the visible products on desktop and mobile

## Testing
- npm run lint
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d50d499c208322964f1c32b143ff08