### PR TITLE
Improve form accessibility and search UX

### DIFF
--- a/src/app/checkout/page.tsx
+++ b/src/app/checkout/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useMemo, useState, useId } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { z } from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -121,6 +121,22 @@ export default function CheckoutPage() {
   const [shippingDetails, setShippingDetails] =
     useState<CheckoutFormValues | null>(null);
   const [selectedPayment, setSelectedPayment] = useState<string>("");
+  const formBaseId = useId();
+  const fieldIds = useMemo(
+    () => ({
+      fullName: `${formBaseId}-full-name`,
+      email: `${formBaseId}-email`,
+      phone: `${formBaseId}-phone`,
+      division: `${formBaseId}-division`,
+      city: `${formBaseId}-city`,
+      postalCode: `${formBaseId}-postal-code`,
+      addressLine1: `${formBaseId}-address-line-1`,
+      apartment: `${formBaseId}-apartment`,
+      roadNo: `${formBaseId}-road-no`,
+      additionalInfo: `${formBaseId}-additional-info`,
+    }),
+    [formBaseId]
+  );
 
   const {
     control,
@@ -375,24 +391,42 @@ export default function CheckoutPage() {
               >
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
                   <div>
-                    <label className="mb-2 block text-sm font-medium text-black">
+                    <label
+                      htmlFor={fieldIds.fullName}
+                      className="mb-2 block text-sm font-medium text-black"
+                    >
                       Full name
                     </label>
                     <InputGroup className="bg-[#F0F0F0]">
                       <InputGroup.Input
                         placeholder="e.g. Rahim Uddin"
                         className="bg-transparent"
+                        id={fieldIds.fullName}
+                        autoComplete="name"
+                        aria-invalid={errors.fullName ? "true" : "false"}
+                        aria-describedby={
+                          errors.fullName
+                            ? `${fieldIds.fullName}-error`
+                            : undefined
+                        }
                         {...register("fullName")}
                       />
                     </InputGroup>
                     {errors.fullName && (
-                      <p className="mt-2 text-sm text-red-500">
+                      <p
+                        id={`${fieldIds.fullName}-error`}
+                        className="mt-2 text-sm text-red-500"
+                        role="alert"
+                      >
                         {errors.fullName.message}
                       </p>
                     )}
                   </div>
                   <div>
-                    <label className="mb-2 block text-sm font-medium text-black">
+                    <label
+                      htmlFor={fieldIds.email}
+                      className="mb-2 block text-sm font-medium text-black"
+                    >
                       Email address
                     </label>
                     <InputGroup className="bg-[#F0F0F0]">
@@ -400,11 +434,23 @@ export default function CheckoutPage() {
                         type="email"
                         placeholder="name@example.com"
                         className="bg-transparent"
+                        id={fieldIds.email}
+                        autoComplete="email"
+                        aria-invalid={errors.email ? "true" : "false"}
+                        aria-describedby={
+                          errors.email
+                            ? `${fieldIds.email}-error`
+                            : undefined
+                        }
                         {...register("email")}
                       />
                     </InputGroup>
                     {errors.email && (
-                      <p className="mt-2 text-sm text-red-500">
+                      <p
+                        id={`${fieldIds.email}-error`}
+                        className="mt-2 text-sm text-red-500"
+                        role="alert"
+                      >
                         {errors.email.message}
                       </p>
                     )}
@@ -412,7 +458,10 @@ export default function CheckoutPage() {
                 </div>
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
                   <div>
-                    <label className="mb-2 block text-sm font-medium text-black">
+                    <label
+                      htmlFor={fieldIds.phone}
+                      className="mb-2 block text-sm font-medium text-black"
+                    >
                       Phone number
                     </label>
                     <InputGroup className="bg-[#F0F0F0]">
@@ -420,17 +469,32 @@ export default function CheckoutPage() {
                         type="tel"
                         placeholder="01XXXXXXXXX"
                         className="bg-transparent"
+                        id={fieldIds.phone}
+                        autoComplete="tel"
+                        aria-invalid={errors.phone ? "true" : "false"}
+                        aria-describedby={
+                          errors.phone
+                            ? `${fieldIds.phone}-error`
+                            : undefined
+                        }
                         {...register("phone")}
                       />
                     </InputGroup>
                     {errors.phone && (
-                      <p className="mt-2 text-sm text-red-500">
+                      <p
+                        id={`${fieldIds.phone}-error`}
+                        className="mt-2 text-sm text-red-500"
+                        role="alert"
+                      >
                         {errors.phone.message}
                       </p>
                     )}
                   </div>
                   <div>
-                    <label className="mb-2 block text-sm font-medium text-black">
+                    <label
+                      htmlFor={fieldIds.postalCode}
+                      className="mb-2 block text-sm font-medium text-black"
+                    >
                       Postal code
                     </label>
                     <InputGroup className="bg-[#F0F0F0]">
@@ -439,11 +503,23 @@ export default function CheckoutPage() {
                         inputMode="numeric"
                         placeholder="e.g. 1207"
                         className="bg-transparent"
+                        id={fieldIds.postalCode}
+                        autoComplete="postal-code"
+                        aria-invalid={errors.postalCode ? "true" : "false"}
+                        aria-describedby={
+                          errors.postalCode
+                            ? `${fieldIds.postalCode}-error`
+                            : undefined
+                        }
                         {...register("postalCode")}
                       />
                     </InputGroup>
                     {errors.postalCode && (
-                      <p className="mt-2 text-sm text-red-500">
+                      <p
+                        id={`${fieldIds.postalCode}-error`}
+                        className="mt-2 text-sm text-red-500"
+                        role="alert"
+                      >
                         {errors.postalCode.message}
                       </p>
                     )}
@@ -451,7 +527,10 @@ export default function CheckoutPage() {
                 </div>
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
                   <div>
-                    <label className="mb-2 block text-sm font-medium text-black">
+                    <label
+                      htmlFor={fieldIds.division}
+                      className="mb-2 block text-sm font-medium text-black"
+                    >
                       Division
                     </label>
                     <Controller
@@ -464,7 +543,16 @@ export default function CheckoutPage() {
                           }}
                           value={field.value || ""}
                         >
-                          <SelectTrigger className="h-12 rounded-full border-black/20 bg-[#F0F0F0] px-4 text-sm">
+                          <SelectTrigger
+                            id={fieldIds.division}
+                            aria-invalid={errors.division ? "true" : "false"}
+                            aria-describedby={
+                              errors.division
+                                ? `${fieldIds.division}-error`
+                                : undefined
+                            }
+                            className="h-12 rounded-full border-black/20 bg-[#F0F0F0] px-4 text-sm"
+                          >
                             <SelectValue placeholder="Select a division" />
                           </SelectTrigger>
                           <SelectContent className="rounded-2xl border-black/10">
@@ -478,13 +566,20 @@ export default function CheckoutPage() {
                       )}
                     />
                     {errors.division && (
-                      <p className="mt-2 text-sm text-red-500">
+                      <p
+                        id={`${fieldIds.division}-error`}
+                        className="mt-2 text-sm text-red-500"
+                        role="alert"
+                      >
                         {errors.division.message}
                       </p>
                     )}
                   </div>
                   <div>
-                    <label className="mb-2 block text-sm font-medium text-black">
+                    <label
+                      htmlFor={fieldIds.city}
+                      className="mb-2 block text-sm font-medium text-black"
+                    >
                       City / District
                     </label>
                     <Controller
@@ -496,14 +591,23 @@ export default function CheckoutPage() {
                           value={field.value || ""}
                           disabled={availableCities.length === 0}
                         >
-                          <SelectTrigger className="h-12 rounded-full border-black/20 bg-[#F0F0F0] px-4 text-sm disabled:opacity-60">
+                          <SelectTrigger
+                            id={fieldIds.city}
+                            aria-invalid={errors.city ? "true" : "false"}
+                            aria-describedby={
+                              errors.city
+                                ? `${fieldIds.city}-error`
+                                : undefined
+                            }
+                            className="h-12 rounded-full border-black/20 bg-[#F0F0F0] px-4 text-sm disabled:opacity-60"
+                          >
                             <SelectValue
                               placeholder={
                                 availableCities.length > 0
                                   ? "Select a city"
                                   : "Select division first"
-                              }
-                            />
+                            }
+                          />
                           </SelectTrigger>
                           <SelectContent className="rounded-2xl border-black/10">
                             {availableCities.map((city) => (
@@ -516,7 +620,11 @@ export default function CheckoutPage() {
                       )}
                     />
                     {errors.city && (
-                      <p className="mt-2 text-sm text-red-500">
+                      <p
+                        id={`${fieldIds.city}-error`}
+                        className="mt-2 text-sm text-red-500"
+                        role="alert"
+                      >
                         {errors.city.message}
                       </p>
                     )}
@@ -524,30 +632,52 @@ export default function CheckoutPage() {
                 </div>
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
                   <div>
-                    <label className="mb-2 block text-sm font-medium text-black">
+                    <label
+                      htmlFor={fieldIds.addressLine1}
+                      className="mb-2 block text-sm font-medium text-black"
+                    >
                       Street address
                     </label>
                     <InputGroup className="bg-[#F0F0F0]">
                       <InputGroup.Input
                         placeholder="House, road number"
                         className="bg-transparent"
+                        id={fieldIds.addressLine1}
+                        autoComplete="street-address"
+                        aria-invalid={
+                          errors.addressLine1 ? "true" : "false"
+                        }
+                        aria-describedby={
+                          errors.addressLine1
+                            ? `${fieldIds.addressLine1}-error`
+                            : undefined
+                        }
                         {...register("addressLine1")}
                       />
                     </InputGroup>
                     {errors.addressLine1 && (
-                      <p className="mt-2 text-sm text-red-500">
+                      <p
+                        id={`${fieldIds.addressLine1}-error`}
+                        className="mt-2 text-sm text-red-500"
+                        role="alert"
+                      >
                         {errors.addressLine1.message}
                       </p>
                     )}
                   </div>
                   <div>
-                    <label className="mb-2 block text-sm font-medium text-black">
+                    <label
+                      htmlFor={fieldIds.apartment}
+                      className="mb-2 block text-sm font-medium text-black"
+                    >
                       Apartment / Floor (optional)
                     </label>
                     <InputGroup className="bg-[#F0F0F0]">
                       <InputGroup.Input
                         placeholder="Apartment, floor, block"
                         className="bg-transparent"
+                        id={fieldIds.apartment}
+                        autoComplete="address-line2"
                         {...register("apartment")}
                       />
                     </InputGroup>
@@ -555,23 +685,32 @@ export default function CheckoutPage() {
                 </div>
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
                   <div>
-                    <label className="mb-2 block text-sm font-medium text-black">
+                    <label
+                      htmlFor={fieldIds.roadNo}
+                      className="mb-2 block text-sm font-medium text-black"
+                    >
                       Road number (optional)
                     </label>
                     <InputGroup className="bg-[#F0F0F0]">
                       <InputGroup.Input
                         placeholder="Road / holding number"
                         className="bg-transparent"
+                        id={fieldIds.roadNo}
+                        autoComplete="address-line2"
                         {...register("roadNo")}
                       />
                     </InputGroup>
                   </div>
                   <div>
-                    <label className="mb-2 block text-sm font-medium text-black">
+                    <label
+                      htmlFor={fieldIds.additionalInfo}
+                      className="mb-2 block text-sm font-medium text-black"
+                    >
                       Delivery notes (optional)
                     </label>
                     <div className="rounded-2xl border border-black/10 bg-[#F0F0F0] px-4 py-3">
                       <textarea
+                        id={fieldIds.additionalInfo}
                         rows={3}
                         className="h-full w-full resize-none bg-transparent text-sm outline-none placeholder:text-sm placeholder:text-black/40"
                         placeholder="Nearby landmark or delivery instruction"

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useId, useMemo, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useForm } from "react-hook-form";
@@ -56,6 +56,14 @@ const getStoredUsers = () => {
 export default function LoginPage() {
   const router = useRouter();
   const [isMounted, setIsMounted] = useState(false);
+  const fieldBaseId = useId();
+  const fieldIds = useMemo(
+    () => ({
+      email: `${fieldBaseId}-email`,
+      password: `${fieldBaseId}-password`,
+    }),
+    [fieldBaseId]
+  );
   const {
     register,
     handleSubmit,
@@ -124,7 +132,10 @@ export default function LoginPage() {
 
           <form onSubmit={handleSubmit(onSubmit)} className="mt-8 space-y-6">
             <div>
-              <label className="mb-2 block text-sm font-medium text-black">
+              <label
+                htmlFor={fieldIds.email}
+                className="mb-2 block text-sm font-medium text-black"
+              >
                 Email address
               </label>
               <InputGroup className="bg-[#F0F0F0]">
@@ -132,16 +143,31 @@ export default function LoginPage() {
                   type="email"
                   placeholder="name@example.com"
                   className="bg-transparent"
+                  id={fieldIds.email}
+                  autoComplete="email"
+                  aria-invalid={errors.email ? "true" : "false"}
+                  aria-describedby={
+                    errors.email ? `${fieldIds.email}-error` : undefined
+                  }
                   {...register("email")}
                 />
               </InputGroup>
               {errors.email && (
-                <p className="mt-2 text-sm text-red-500">{errors.email.message}</p>
+                <p
+                  id={`${fieldIds.email}-error`}
+                  className="mt-2 text-sm text-red-500"
+                  role="alert"
+                >
+                  {errors.email.message}
+                </p>
               )}
             </div>
 
             <div>
-              <label className="mb-2 block text-sm font-medium text-black">
+              <label
+                htmlFor={fieldIds.password}
+                className="mb-2 block text-sm font-medium text-black"
+              >
                 Password
               </label>
               <InputGroup className="bg-[#F0F0F0]">
@@ -149,11 +175,23 @@ export default function LoginPage() {
                   type="password"
                   placeholder="Enter your password"
                   className="bg-transparent"
+                  id={fieldIds.password}
+                  autoComplete="current-password"
+                  aria-invalid={errors.password ? "true" : "false"}
+                  aria-describedby={
+                    errors.password
+                      ? `${fieldIds.password}-error`
+                      : undefined
+                  }
                   {...register("password")}
                 />
               </InputGroup>
               {errors.password && (
-                <p className="mt-2 text-sm text-red-500">
+                <p
+                  id={`${fieldIds.password}-error`}
+                  className="mt-2 text-sm text-red-500"
+                  role="alert"
+                >
                   {errors.password.message}
                 </p>
               )}

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { FormEvent, useEffect, useMemo, useState } from "react";
+import { FormEvent, useEffect, useMemo, useState, useId } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import InputGroup from "@/components/ui/input-group";
 import { Button } from "@/components/ui/button";
@@ -24,6 +24,7 @@ export default function SearchPage() {
   const searchParams = useSearchParams();
   const queryFromParams = searchParams.get("q") ?? "";
   const [searchTerm, setSearchTerm] = useState(queryFromParams);
+  const searchInputId = useId();
 
   useEffect(() => {
     setSearchTerm(queryFromParams);
@@ -87,6 +88,9 @@ export default function SearchPage() {
             onSubmit={handleSubmit}
             className="mt-6 flex flex-col space-y-3 sm:flex-row sm:items-center sm:space-y-0 sm:space-x-3"
           >
+            <label className="sr-only" htmlFor={searchInputId}>
+              Search for products
+            </label>
             <InputGroup className="bg-[#F0F0F0] max-w-2xl">
               <InputGroup.Input
                 type="search"
@@ -95,6 +99,8 @@ export default function SearchPage() {
                 onChange={(event) => setSearchTerm(event.target.value)}
                 placeholder={'Try "t-shirt", "casual" or "black"'}
                 className="bg-transparent placeholder:text-black/40"
+                id={searchInputId}
+                autoComplete="off"
               />
             </InputGroup>
             <Button

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useId, useMemo, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useForm } from "react-hook-form";
@@ -62,6 +62,17 @@ const getStoredUsers = () => {
 export default function SignupPage() {
   const router = useRouter();
   const [isMounted, setIsMounted] = useState(false);
+  const fieldBaseId = useId();
+  const fieldIds = useMemo(
+    () => ({
+      fullName: `${fieldBaseId}-full-name`,
+      email: `${fieldBaseId}-email`,
+      phone: `${fieldBaseId}-phone`,
+      password: `${fieldBaseId}-password`,
+      confirmPassword: `${fieldBaseId}-confirm-password`,
+    }),
+    [fieldBaseId]
+  );
   const {
     register,
     handleSubmit,
@@ -128,25 +139,43 @@ export default function SignupPage() {
 
           <form onSubmit={handleSubmit(onSubmit)} className="mt-8 space-y-6">
             <div>
-              <label className="mb-2 block text-sm font-medium text-black">
+              <label
+                htmlFor={fieldIds.fullName}
+                className="mb-2 block text-sm font-medium text-black"
+              >
                 Full name
               </label>
               <InputGroup className="bg-[#F0F0F0]">
                 <InputGroup.Input
                   placeholder="e.g. Nafisa Karim"
                   className="bg-transparent"
+                  id={fieldIds.fullName}
+                  autoComplete="name"
+                  aria-invalid={errors.fullName ? "true" : "false"}
+                  aria-describedby={
+                    errors.fullName
+                      ? `${fieldIds.fullName}-error`
+                      : undefined
+                  }
                   {...register("fullName")}
                 />
               </InputGroup>
               {errors.fullName && (
-                <p className="mt-2 text-sm text-red-500">
+                <p
+                  id={`${fieldIds.fullName}-error`}
+                  className="mt-2 text-sm text-red-500"
+                  role="alert"
+                >
                   {errors.fullName.message}
                 </p>
               )}
             </div>
 
             <div>
-              <label className="mb-2 block text-sm font-medium text-black">
+              <label
+                htmlFor={fieldIds.email}
+                className="mb-2 block text-sm font-medium text-black"
+              >
                 Email address
               </label>
               <InputGroup className="bg-[#F0F0F0]">
@@ -154,16 +183,31 @@ export default function SignupPage() {
                   type="email"
                   placeholder="name@example.com"
                   className="bg-transparent"
+                  id={fieldIds.email}
+                  autoComplete="email"
+                  aria-invalid={errors.email ? "true" : "false"}
+                  aria-describedby={
+                    errors.email ? `${fieldIds.email}-error` : undefined
+                  }
                   {...register("email")}
                 />
               </InputGroup>
               {errors.email && (
-                <p className="mt-2 text-sm text-red-500">{errors.email.message}</p>
+                <p
+                  id={`${fieldIds.email}-error`}
+                  className="mt-2 text-sm text-red-500"
+                  role="alert"
+                >
+                  {errors.email.message}
+                </p>
               )}
             </div>
 
             <div>
-              <label className="mb-2 block text-sm font-medium text-black">
+              <label
+                htmlFor={fieldIds.phone}
+                className="mb-2 block text-sm font-medium text-black"
+              >
                 Mobile number
               </label>
               <InputGroup className="bg-[#F0F0F0]">
@@ -171,16 +215,31 @@ export default function SignupPage() {
                   type="tel"
                   placeholder="01XXXXXXXXX"
                   className="bg-transparent"
+                  id={fieldIds.phone}
+                  autoComplete="tel"
+                  aria-invalid={errors.phone ? "true" : "false"}
+                  aria-describedby={
+                    errors.phone ? `${fieldIds.phone}-error` : undefined
+                  }
                   {...register("phone")}
                 />
               </InputGroup>
               {errors.phone && (
-                <p className="mt-2 text-sm text-red-500">{errors.phone.message}</p>
+                <p
+                  id={`${fieldIds.phone}-error`}
+                  className="mt-2 text-sm text-red-500"
+                  role="alert"
+                >
+                  {errors.phone.message}
+                </p>
               )}
             </div>
 
             <div>
-              <label className="mb-2 block text-sm font-medium text-black">
+              <label
+                htmlFor={fieldIds.password}
+                className="mb-2 block text-sm font-medium text-black"
+              >
                 Password
               </label>
               <InputGroup className="bg-[#F0F0F0]">
@@ -188,18 +247,33 @@ export default function SignupPage() {
                   type="password"
                   placeholder="Create a strong password"
                   className="bg-transparent"
+                  id={fieldIds.password}
+                  autoComplete="new-password"
+                  aria-invalid={errors.password ? "true" : "false"}
+                  aria-describedby={
+                    errors.password
+                      ? `${fieldIds.password}-error`
+                      : undefined
+                  }
                   {...register("password")}
                 />
               </InputGroup>
               {errors.password && (
-                <p className="mt-2 text-sm text-red-500">
+                <p
+                  id={`${fieldIds.password}-error`}
+                  className="mt-2 text-sm text-red-500"
+                  role="alert"
+                >
                   {errors.password.message}
                 </p>
               )}
             </div>
 
             <div>
-              <label className="mb-2 block text-sm font-medium text-black">
+              <label
+                htmlFor={fieldIds.confirmPassword}
+                className="mb-2 block text-sm font-medium text-black"
+              >
                 Confirm password
               </label>
               <InputGroup className="bg-[#F0F0F0]">
@@ -207,11 +281,23 @@ export default function SignupPage() {
                   type="password"
                   placeholder="Re-enter your password"
                   className="bg-transparent"
+                  id={fieldIds.confirmPassword}
+                  autoComplete="new-password"
+                  aria-invalid={errors.confirmPassword ? "true" : "false"}
+                  aria-describedby={
+                    errors.confirmPassword
+                      ? `${fieldIds.confirmPassword}-error`
+                      : undefined
+                  }
                   {...register("confirmPassword")}
                 />
               </InputGroup>
               {errors.confirmPassword && (
-                <p className="mt-2 text-sm text-red-500">
+                <p
+                  id={`${fieldIds.confirmPassword}-error`}
+                  className="mt-2 text-sm text-red-500"
+                  role="alert"
+                >
                   {errors.confirmPassword.message}
                 </p>
               )}

--- a/src/components/layout/Navbar/TopNavbar/index.tsx
+++ b/src/components/layout/Navbar/TopNavbar/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { FormEvent, Fragment, useEffect, useState } from "react";
+import { FormEvent, Fragment, useEffect, useId, useState } from "react";
 import { cn } from "@/lib/utils";
 import { integralCF } from "@/styles/fonts";
 import Link from "next/link";
@@ -77,6 +77,7 @@ const TopNavbar = () => {
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const [searchTerm, setSearchTerm] = useState("");
+  const searchInputId = useId();
 
   useEffect(() => {
     if (pathname === "/search") {
@@ -133,6 +134,9 @@ const TopNavbar = () => {
           onSubmit={handleSearchSubmit}
           className="hidden md:flex w-full max-w-[320px] lg:max-w-md mr-3 lg:mr-10"
         >
+          <label className="sr-only" htmlFor={searchInputId}>
+            Search products
+          </label>
           <InputGroup className="bg-[#F0F0F0]">
             <InputGroup.Text className="pl-0">
               <button
@@ -157,6 +161,8 @@ const TopNavbar = () => {
               onChange={(event) => setSearchTerm(event.target.value)}
               placeholder="Search for products..."
               className="bg-transparent placeholder:text-black/40"
+              id={searchInputId}
+              autoComplete="off"
             />
           </InputGroup>
         </form>


### PR DESCRIPTION
## Summary
- add stable field identifiers and aria attributes to the login, signup and checkout forms so labels and errors are announced correctly while keeping useful browser autocomplete hints
- enhance checkout delivery step by labelling custom selects and delivery notes textarea for assistive technologies
- expose accessible labels and ids for the header and search page search inputs to keep navigation consistent across viewports

## Testing
- npm run lint
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d5b9bece4c83228782af84c4726677