### PR TITLE
Ensure Prisma migrations run during postinstall

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ To get started with Shopco locally, follow these steps:
 
    If you are working offline, you can generate the SQL script with `npx prisma migrate diff --from-empty --to-schema-datamodel prisma/schema.prisma --script` and apply it manually to your database.
 
+   > **Tip:** The project automatically runs `prisma generate` and, when `DATABASE_URL` is configured, `prisma migrate deploy` after `npm install`. Set `SKIP_PRISMA_MIGRATE=true` if you need to skip migrations during installation.
+
 5. **Run the development server:**
 
    ```bash

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "postinstall": "node scripts/prisma-postinstall.mjs"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",

--- a/scripts/prisma-postinstall.mjs
+++ b/scripts/prisma-postinstall.mjs
@@ -1,0 +1,36 @@
+import { execSync } from "node:child_process";
+
+const run = (command, options = {}) => {
+  execSync(command, {
+    stdio: "inherit",
+    ...options,
+  });
+};
+
+try {
+  run("npx prisma generate");
+} catch (error) {
+  console.error("prisma generate failed during postinstall.");
+  throw error;
+}
+
+const shouldSkipMigrate = process.env.SKIP_PRISMA_MIGRATE === "true";
+
+if (shouldSkipMigrate) {
+  console.log("SKIP_PRISMA_MIGRATE=true, skipping prisma migrate deploy.");
+  process.exit(0);
+}
+
+if (!process.env.DATABASE_URL) {
+  console.warn(
+    "DATABASE_URL is not set; skipping prisma migrate deploy during postinstall."
+  );
+  process.exit(0);
+}
+
+try {
+  run("npx prisma migrate deploy");
+} catch (error) {
+  console.error("prisma migrate deploy failed during postinstall.");
+  throw error;
+}


### PR DESCRIPTION
## Summary
- add a postinstall script that runs prisma generate and migrate deploy when a DATABASE_URL is available
- allow skipping the automated migration with a SKIP_PRISMA_MIGRATE flag and document the behavior in the README

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68d7e4c1b0d88322b61451b61abfb8ba