### PR TITLE
Add support workflows and account management enhancements

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -19,6 +19,8 @@ model User {
   createdAt    DateTime  @default(now())
   updatedAt    DateTime  @updatedAt
   sessions     Session[]
+  orders       Order[]
+  supportMessages SupportMessage[]
 }
 
 model Session {
@@ -28,4 +30,40 @@ model Session {
   userId    String
   createdAt DateTime @default(now())
   expiresAt DateTime
+}
+
+model Order {
+  id                String   @id @default(cuid())
+  orderNumber       String   @unique
+  user              User?    @relation(fields: [userId], references: [id], onDelete: SetNull)
+  userId            String?
+  placedOn          DateTime @default(now())
+  totalAmount       Int
+  itemsCount        Int
+  status            String
+  paymentMethod     String
+  estimatedDelivery DateTime?
+  notes             String?
+  shippingName      String
+  shippingPhone     String
+  shippingAddress1  String
+  shippingAddress2  String?
+  shippingCity      String
+  shippingPostal    String
+  statusHistory     Json
+  createdAt         DateTime @default(now())
+  updatedAt         DateTime @updatedAt
+}
+
+model SupportMessage {
+  id        String   @id @default(cuid())
+  user      User?    @relation(fields: [userId], references: [id], onDelete: SetNull)
+  userId    String?
+  fullName  String
+  email     String
+  subject   String
+  message   String
+  orderNumber String?
+  createdAt DateTime @default(now())
+  resolved  Boolean  @default(false)
 }

--- a/src/app/api/auth/password/route.ts
+++ b/src/app/api/auth/password/route.ts
@@ -1,0 +1,93 @@
+import { cookies } from "next/headers";
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import bcrypt from "bcryptjs";
+
+import { prisma } from "@/lib/prisma";
+import { SESSION_COOKIE_NAME, requireCurrentUser } from "@/lib/auth";
+
+const passwordSchema = z
+  .object({
+    currentPassword: z
+      .string({ required_error: "Current password is required" })
+      .min(1, "Current password is required"),
+    newPassword: z
+      .string({ required_error: "New password is required" })
+      .min(6, "New password must be at least 6 characters"),
+    confirmPassword: z
+      .string({ required_error: "Confirm your new password" })
+      .min(6, "Confirm password must be at least 6 characters"),
+  })
+  .refine((data) => data.newPassword === data.confirmPassword, {
+    message: "Passwords do not match",
+    path: ["confirmPassword"],
+  });
+
+export async function PATCH(request: Request) {
+  const maybeUser = await requireCurrentUser();
+
+  if (maybeUser instanceof NextResponse) {
+    return maybeUser;
+  }
+
+  const body = await request.json().catch(() => null);
+  const parsed = passwordSchema.safeParse(body);
+
+  if (!parsed.success) {
+    const message = parsed.error.issues[0]?.message ?? "Invalid request";
+    return NextResponse.json({ message }, { status: 400 });
+  }
+
+  const { currentPassword, newPassword } = parsed.data;
+
+  const user = await prisma.user.findUnique({
+    where: { id: maybeUser.id },
+    select: { passwordHash: true },
+  });
+
+  if (!user) {
+    return NextResponse.json({ message: "User not found" }, { status: 404 });
+  }
+
+  const matches = await bcrypt.compare(currentPassword, user.passwordHash);
+
+  if (!matches) {
+    return NextResponse.json(
+      { message: "Your current password is incorrect" },
+      { status: 400 }
+    );
+  }
+
+  const isSamePassword = await bcrypt.compare(newPassword, user.passwordHash);
+
+  if (isSamePassword) {
+    return NextResponse.json(
+      { message: "Choose a password you haven't used before" },
+      { status: 400 }
+    );
+  }
+
+  const hashed = await bcrypt.hash(newPassword, 12);
+
+  await prisma.user.update({
+    where: { id: maybeUser.id },
+    data: { passwordHash: hashed },
+  });
+
+  const currentToken = cookies().get(SESSION_COOKIE_NAME)?.value;
+
+  await prisma.session.deleteMany({
+    where: {
+      userId: maybeUser.id,
+      ...(currentToken
+        ? {
+            NOT: {
+              token: currentToken,
+            },
+          }
+        : {}),
+    },
+  });
+
+  return NextResponse.json({ message: "Password updated successfully" });
+}

--- a/src/app/api/orders/[orderNumber]/route.ts
+++ b/src/app/api/orders/[orderNumber]/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from "next/server";
+
+import { prisma } from "@/lib/prisma";
+import { serializeOrder } from "@/lib/serializers/order";
+
+export async function GET(
+  request: Request,
+  { params }: { params: { orderNumber: string } }
+) {
+  const order = await prisma.order.findUnique({
+    where: { orderNumber: params.orderNumber },
+  });
+
+  if (!order) {
+    return NextResponse.json(
+      { message: "Order not found" },
+      { status: 404 }
+    );
+  }
+
+  return NextResponse.json({ order: serializeOrder(order) });
+}

--- a/src/app/api/orders/route.ts
+++ b/src/app/api/orders/route.ts
@@ -1,0 +1,84 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+import { getCurrentUser } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import type { OrderTimelineStep } from "@/lib/data/orders";
+import { serializeOrder } from "@/lib/serializers/order";
+
+const timelineStepSchema: z.ZodType<OrderTimelineStep> = z.object({
+  id: z.string().min(1, "Timeline step ID is required"),
+  title: z.string().min(1, "Step title is required"),
+  description: z.string().min(1, "Step description is required"),
+  date: z.string().datetime().optional(),
+  isCompleted: z.boolean(),
+});
+
+const shippingSchema = z.object({
+  name: z.string().min(1, "Recipient name is required"),
+  phone: z.string().min(1, "Recipient phone number is required"),
+  addressLine1: z.string().min(1, "Primary address line is required"),
+  addressLine2: z.string().optional(),
+  city: z.string().min(1, "City is required"),
+  postalCode: z.string().min(1, "Postal code is required"),
+});
+
+const createOrderSchema = z.object({
+  orderNumber: z.string().min(1, "Order number is required"),
+  placedOn: z.string().datetime().optional(),
+  totalAmount: z.number().int().nonnegative(),
+  itemsCount: z.number().int().nonnegative(),
+  status: z.string().min(1, "Order status is required"),
+  paymentMethod: z.string().min(1, "Payment method is required"),
+  estimatedDelivery: z.string().datetime().optional(),
+  notes: z.string().max(1000).optional(),
+  shippingAddress: shippingSchema,
+  statusHistory: z.array(timelineStepSchema).min(1),
+});
+
+export async function POST(request: Request) {
+  const body = await request.json().catch(() => null);
+
+  const parsed = createOrderSchema.safeParse(body);
+
+  if (!parsed.success) {
+    const message = parsed.error.issues[0]?.message ?? "Invalid request";
+    return NextResponse.json({ message }, { status: 400 });
+  }
+
+  const user = await getCurrentUser();
+  const payload = parsed.data;
+
+  try {
+    const created = await prisma.order.create({
+      data: {
+        orderNumber: payload.orderNumber,
+        userId: user?.id,
+        placedOn: payload.placedOn ? new Date(payload.placedOn) : new Date(),
+        totalAmount: payload.totalAmount,
+        itemsCount: payload.itemsCount,
+        status: payload.status,
+        paymentMethod: payload.paymentMethod,
+        estimatedDelivery: payload.estimatedDelivery
+          ? new Date(payload.estimatedDelivery)
+          : null,
+        notes: payload.notes ?? null,
+        shippingName: payload.shippingAddress.name,
+        shippingPhone: payload.shippingAddress.phone,
+        shippingAddress1: payload.shippingAddress.addressLine1,
+        shippingAddress2: payload.shippingAddress.addressLine2 ?? null,
+        shippingCity: payload.shippingAddress.city,
+        shippingPostal: payload.shippingAddress.postalCode,
+        statusHistory: payload.statusHistory,
+      },
+    });
+
+    return NextResponse.json({ order: serializeOrder(created) });
+  } catch (error) {
+    console.error("Failed to create order", error);
+    return NextResponse.json(
+      { message: "We couldn't save your order. Please try again." },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/support/route.ts
+++ b/src/app/api/support/route.ts
@@ -1,0 +1,51 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+import { getCurrentUser } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+
+const supportSchema = z.object({
+  fullName: z.string().min(1, "Full name is required"),
+  email: z.string().email("Enter a valid email address"),
+  subject: z.string().min(1, "Subject is required").max(150, "Subject is too long"),
+  message: z
+    .string()
+    .min(1, "Message is required")
+    .max(2000, "Message must be 2000 characters or less"),
+  orderNumber: z.string().min(1).optional(),
+});
+
+export async function POST(request: Request) {
+  const body = await request.json().catch(() => null);
+
+  const parsed = supportSchema.safeParse(body);
+
+  if (!parsed.success) {
+    const message = parsed.error.issues[0]?.message ?? "Invalid request";
+    return NextResponse.json({ message }, { status: 400 });
+  }
+
+  const user = await getCurrentUser();
+  const payload = parsed.data;
+
+  try {
+    await prisma.supportMessage.create({
+      data: {
+        userId: user?.id,
+        fullName: payload.fullName,
+        email: payload.email,
+        subject: payload.subject,
+        message: payload.message,
+        orderNumber: payload.orderNumber,
+      },
+    });
+
+    return NextResponse.json({ message: "Your message has been received" });
+  } catch (error) {
+    console.error("Failed to store support message", error);
+    return NextResponse.json(
+      { message: "We couldn't submit your request. Please try again." },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/support/page.tsx
+++ b/src/app/support/page.tsx
@@ -1,0 +1,263 @@
+"use client";
+
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { toast } from "react-toastify";
+import Link from "next/link";
+
+import { Button } from "@/components/ui/button";
+import InputGroup from "@/components/ui/input-group";
+import { cn } from "@/lib/utils";
+import { integralCF } from "@/styles/fonts";
+
+const supportSchema = z.object({
+  fullName: z
+    .string({ required_error: "Full name is required" })
+    .min(1, "Full name is required"),
+  email: z
+    .string({ required_error: "Email is required" })
+    .min(1, "Email is required")
+    .email("Enter a valid email address"),
+  subject: z
+    .string({ required_error: "Subject is required" })
+    .min(1, "Subject is required")
+    .max(150, "Subject is too long"),
+  orderNumber: z.string().optional(),
+  message: z
+    .string({ required_error: "Message is required" })
+    .min(1, "Message is required")
+    .max(2000, "Message is too long"),
+});
+
+type SupportFormValues = z.infer<typeof supportSchema>;
+
+export default function SupportPage() {
+  const [hasSubmitted, setHasSubmitted] = useState(false);
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors, isSubmitting },
+  } = useForm<SupportFormValues>({
+    resolver: zodResolver(supportSchema),
+    defaultValues: {
+      fullName: "",
+      email: "",
+      subject: "",
+      orderNumber: "",
+      message: "",
+    },
+  });
+
+  const onSubmit = async (values: SupportFormValues) => {
+    try {
+      const response = await fetch("/api/support", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(values),
+      });
+
+      const data = (await response.json().catch(() => null)) as
+        | { message?: string }
+        | null;
+
+      if (!response.ok) {
+        toast.error(
+          data?.message ??
+            "We couldn't send your message. Please try again shortly."
+        );
+        return;
+      }
+
+      toast.success("Thanks! Our team will be in touch soon.");
+      setHasSubmitted(true);
+      reset();
+    } catch (error) {
+      console.error("Failed to submit support request", error);
+      toast.error("We couldn't send your message. Please try again shortly.");
+    }
+  };
+
+  return (
+    <main className="pb-20">
+      <div className="max-w-frame mx-auto px-4 xl:px-0">
+        <header className="pt-8 pb-10 sm:pb-12">
+          <h1
+            className={cn(
+              integralCF.className,
+              "text-3xl sm:text-[40px] font-bold uppercase text-black"
+            )}
+          >
+            We&apos;re here to help
+          </h1>
+          <p className="mt-3 max-w-3xl text-base text-black/60">
+            Send us a message and our support team will respond within 24 hours.
+            You can also browse our <Link href="/order-tracking" className="font-semibold text-black underline">order tracking</Link> page for delivery updates.
+          </p>
+        </header>
+
+        <div className="grid gap-6 lg:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]">
+          <section className="space-y-6 rounded-[24px] border border-black/10 bg-white p-6 sm:p-8">
+            <div>
+              <h2 className="text-xl font-semibold text-black">
+                Contact support
+              </h2>
+              <p className="mt-1 text-sm text-black/60">
+                Fill out the form below and we&apos;ll get back to you as soon as we
+                can.
+              </p>
+            </div>
+
+            <form onSubmit={handleSubmit(onSubmit)} className="space-y-5">
+              <div className="grid gap-5 sm:grid-cols-2">
+                <div>
+                  <label className="mb-2 block text-sm font-medium text-black">
+                    Full name
+                  </label>
+                  <InputGroup className="bg-[#F0F0F0]">
+                    <InputGroup.Input
+                      type="text"
+                      placeholder="Your full name"
+                      className="bg-transparent"
+                      autoComplete="name"
+                      aria-invalid={errors.fullName ? "true" : "false"}
+                      {...register("fullName")}
+                    />
+                  </InputGroup>
+                  {errors.fullName && (
+                    <p className="mt-2 text-sm text-red-500">
+                      {errors.fullName.message}
+                    </p>
+                  )}
+                </div>
+                <div>
+                  <label className="mb-2 block text-sm font-medium text-black">
+                    Email address
+                  </label>
+                  <InputGroup className="bg-[#F0F0F0]">
+                    <InputGroup.Input
+                      type="email"
+                      placeholder="name@example.com"
+                      className="bg-transparent"
+                      autoComplete="email"
+                      aria-invalid={errors.email ? "true" : "false"}
+                      {...register("email")}
+                    />
+                  </InputGroup>
+                  {errors.email && (
+                    <p className="mt-2 text-sm text-red-500">
+                      {errors.email.message}
+                    </p>
+                  )}
+                </div>
+              </div>
+
+              <div>
+                <label className="mb-2 block text-sm font-medium text-black">
+                  Subject
+                </label>
+                <InputGroup className="bg-[#F0F0F0]">
+                  <InputGroup.Input
+                    type="text"
+                    placeholder="How can we help?"
+                    className="bg-transparent"
+                    aria-invalid={errors.subject ? "true" : "false"}
+                    {...register("subject")}
+                  />
+                </InputGroup>
+                {errors.subject && (
+                  <p className="mt-2 text-sm text-red-500">
+                    {errors.subject.message}
+                  </p>
+                )}
+              </div>
+
+              <div>
+                <label className="mb-2 block text-sm font-medium text-black">
+                  Order ID (optional)
+                </label>
+                <InputGroup className="bg-[#F0F0F0]">
+                  <InputGroup.Input
+                    type="text"
+                    placeholder="e.g. TSR-105284"
+                    className="bg-transparent uppercase"
+                    aria-invalid={errors.orderNumber ? "true" : "false"}
+                    {...register("orderNumber")}
+                  />
+                </InputGroup>
+                {errors.orderNumber && (
+                  <p className="mt-2 text-sm text-red-500">
+                    {errors.orderNumber.message}
+                  </p>
+                )}
+              </div>
+
+              <div>
+                <label className="mb-2 block text-sm font-medium text-black">
+                  Message
+                </label>
+                <div className="rounded-[20px] border border-black/10 bg-[#F0F0F0] p-4">
+                  <textarea
+                    rows={6}
+                    placeholder="Tell us more about the issue you&apos;re experiencing"
+                    className="w-full resize-none bg-transparent text-sm text-black outline-none"
+                    aria-invalid={errors.message ? "true" : "false"}
+                    {...register("message")}
+                  />
+                </div>
+                {errors.message && (
+                  <p className="mt-2 text-sm text-red-500">
+                    {errors.message.message}
+                  </p>
+                )}
+              </div>
+
+              <Button
+                type="submit"
+                disabled={isSubmitting}
+                className="h-[52px] w-full rounded-full bg-black px-6 text-sm font-semibold text-white disabled:cursor-not-allowed disabled:bg-black/50"
+              >
+                {isSubmitting ? "Sending…" : "Send message"}
+              </Button>
+
+              {hasSubmitted && (
+                <p className="text-sm text-emerald-600">
+                  We&apos;ve received your message. You&apos;ll hear from us very soon.
+                </p>
+              )}
+            </form>
+          </section>
+
+          <aside className="space-y-6 rounded-[24px] border border-black/10 bg-[#F7F7F7] p-6 sm:p-8">
+            <div>
+              <h2 className="text-xl font-semibold text-black">
+                Quick answers
+              </h2>
+              <p className="mt-1 text-sm text-black/60">
+                Check our <Link href="/order-tracking" className="font-semibold text-black underline">order tracking</Link> page to see the latest status of your delivery.
+              </p>
+            </div>
+            <div className="space-y-4 text-sm text-black/70">
+              <div>
+                <p className="font-semibold text-black">Business hours</p>
+                <p>Saturday - Thursday, 9am to 8pm BST</p>
+              </div>
+              <div>
+                <p className="font-semibold text-black">Email</p>
+                <p>support@tsrfashion.com</p>
+              </div>
+              <div>
+                <p className="font-semibold text-black">Hotline</p>
+                <p>+880 9611-123456</p>
+              </div>
+            </div>
+          </aside>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/components/layout/Navbar/TopNavbar/ResTopNavbar.tsx
+++ b/src/components/layout/Navbar/TopNavbar/ResTopNavbar.tsx
@@ -103,6 +103,14 @@ const ResTopNavbar = ({ data }: { data: NavMenu }) => {
                 Track your order
               </Link>
             </SheetClose>
+            <SheetClose asChild>
+              <Link
+                href="/support"
+                className="rounded-full border border-black/15 px-4 py-2 text-sm font-medium text-black/70"
+              >
+                Get support
+              </Link>
+            </SheetClose>
             <div className="flex space-x-3">
               <SheetClose asChild>
                 <Link

--- a/src/components/layout/Navbar/TopNavbar/index.tsx
+++ b/src/components/layout/Navbar/TopNavbar/index.tsx
@@ -63,6 +63,13 @@ const data: NavMenu = [
     url: "/shop#new-arrivals",
     children: [],
   },
+  {
+    id: 4,
+    type: "MenuItem",
+    label: "Support",
+    url: "/support",
+    children: [],
+  },
   // {
   //   id: 4,
   //   type: "MenuItem",

--- a/src/lib/serializers/order.ts
+++ b/src/lib/serializers/order.ts
@@ -1,0 +1,36 @@
+import type { Order, Prisma } from "@prisma/client";
+
+import type { OrderTimelineStep, OrderTracking } from "@/lib/data/orders";
+
+type OrderWithHistory = Order & {
+  statusHistory: Prisma.JsonValue;
+};
+
+export const serializeOrder = (order: OrderWithHistory): OrderTracking => {
+  const history = (Array.isArray(order.statusHistory)
+    ? order.statusHistory
+    : []) as OrderTimelineStep[];
+
+  return {
+    id: order.orderNumber,
+    placedOn: order.placedOn.toISOString(),
+    totalAmount: order.totalAmount,
+    itemsCount: order.itemsCount,
+    status: order.status as OrderTracking["status"],
+    paymentMethod: order.paymentMethod,
+    estimatedDelivery: order.estimatedDelivery?.toISOString(),
+    notes: order.notes ?? undefined,
+    shippingAddress: {
+      name: order.shippingName,
+      phone: order.shippingPhone,
+      addressLine1: order.shippingAddress1,
+      addressLine2: order.shippingAddress2 ?? undefined,
+      city: order.shippingCity,
+      postalCode: order.shippingPostal,
+    },
+    statusHistory: history.map((step) => ({
+      ...step,
+      date: step.date,
+    })),
+  };
+};


### PR DESCRIPTION
## Summary
- add order and support persistence to the Prisma schema with REST endpoints for password updates, order creation, and support messages
- enhance the profile experience with account update forms, password changes, logout handling, and checkout/order tracking integrations with the new APIs
- introduce a dedicated support page and surface navigation links for support access

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68d7f19cbb50832286dfafe7278c3a73