### PR TITLE
Add admin role support and dashboard

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,10 @@
     "eslint-config-next": "^15.5.4",
     "postcss": "^8",
     "tailwindcss": "^3.4.1",
+    "tsx": "^4.19.2",
     "typescript": "^5"
+  },
+  "prisma": {
+    "seed": "tsx prisma/seed.ts"
   }
 }

--- a/prisma/migrations/20241008120000_add_user_role/migration.sql
+++ b/prisma/migrations/20241008120000_add_user_role/migration.sql
@@ -1,0 +1,6 @@
+-- CreateEnum
+CREATE TYPE "Role" AS ENUM ('USER', 'ADMIN');
+
+-- AlterTable
+ALTER TABLE "public"."User"
+ADD COLUMN     "role" "Role" NOT NULL DEFAULT 'USER';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -11,16 +11,22 @@ datasource db {
 }
 
 model User {
-  id           String    @id @default(cuid())
-  email        String    @unique
-  fullName     String
-  phone        String?
-  passwordHash String
-  createdAt    DateTime  @default(now())
-  updatedAt    DateTime  @updatedAt
-  sessions     Session[]
-  orders       Order[]
+  id              String           @id @default(cuid())
+  email           String           @unique
+  fullName        String
+  phone           String?
+  passwordHash    String
+  role            Role             @default(USER)
+  createdAt       DateTime         @default(now())
+  updatedAt       DateTime         @updatedAt
+  sessions        Session[]
+  orders          Order[]
   supportMessages SupportMessage[]
+}
+
+enum Role {
+  USER
+  ADMIN
 }
 
 model Session {

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,0 +1,56 @@
+import bcrypt from "bcryptjs";
+import { PrismaClient, Role } from "@prisma/client";
+
+const prisma = new PrismaClient();
+
+const DEFAULT_ADMIN_EMAIL = "admin@tsr-fashion.com";
+const DEFAULT_ADMIN_PASSWORD = "Admin123!";
+const DEFAULT_ADMIN_NAME = "Site Administrator";
+
+const resolveEnv = (key: string, fallback: string) =>
+  process.env[key] && process.env[key]!.trim().length > 0
+    ? process.env[key]!.trim()
+    : fallback;
+
+async function main() {
+  const email = resolveEnv("ADMIN_EMAIL", DEFAULT_ADMIN_EMAIL).toLowerCase();
+  const password = resolveEnv("ADMIN_PASSWORD", DEFAULT_ADMIN_PASSWORD);
+  const fullName = resolveEnv("ADMIN_FULL_NAME", DEFAULT_ADMIN_NAME);
+
+  const passwordHash = await bcrypt.hash(password, 12);
+
+  const admin = await prisma.user.upsert({
+    where: { email },
+    update: {
+      fullName,
+      passwordHash,
+      role: Role.ADMIN,
+    },
+    create: {
+      email,
+      fullName,
+      passwordHash,
+      role: Role.ADMIN,
+    },
+    select: {
+      id: true,
+      email: true,
+      fullName: true,
+      role: true,
+    },
+  });
+
+  console.log("Admin user ready:");
+  console.log(`  Email: ${admin.email}`);
+  console.log(`  Password: ${password}`);
+  console.log(`  Name: ${admin.fullName}`);
+}
+
+main()
+  .catch((error) => {
+    console.error("Seeding admin user failed", error);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,0 +1,235 @@
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import {
+  Clock,
+  DollarSign,
+  PackageSearch,
+  ShoppingBag,
+  Users,
+} from "lucide-react";
+
+import { getCurrentUser } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { Button } from "@/components/ui/button";
+
+const formatCurrency = (value: number) =>
+  new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "BDT",
+    maximumFractionDigits: 0,
+  }).format(value);
+
+const formatDate = (value: Date) =>
+  new Intl.DateTimeFormat("en-GB", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(value);
+
+const formatStatus = (status: string) => {
+  if (!status) {
+    return "Unknown";
+  }
+
+  return status.charAt(0).toUpperCase() + status.slice(1);
+};
+
+export default async function AdminDashboardPage() {
+  const user = await getCurrentUser();
+
+  if (!user) {
+    redirect("/login?redirect=/admin");
+  }
+
+  if (user.role !== "ADMIN") {
+    redirect("/");
+  }
+
+  const [customerCount, orderCount, pendingOrderCount, revenueAggregate, latestOrder] =
+    await prisma.$transaction([
+      prisma.user.count(),
+      prisma.order.count(),
+      prisma.order.count({
+        where: {
+          status: {
+            in: ["pending", "processing"],
+          },
+        },
+      }),
+      prisma.order.aggregate({
+        _sum: { totalAmount: true },
+      }),
+      prisma.order.findFirst({
+        orderBy: { placedOn: "desc" },
+        select: {
+          orderNumber: true,
+          totalAmount: true,
+          status: true,
+          placedOn: true,
+          shippingName: true,
+        },
+      }),
+    ]);
+
+  const totalRevenue = revenueAggregate._sum.totalAmount ?? 0;
+
+  const stats = [
+    {
+      label: "Registered customers",
+      value: customerCount.toLocaleString("en-US"),
+      description: "Unique shopper accounts",
+      icon: Users,
+    },
+    {
+      label: "Total orders",
+      value: orderCount.toLocaleString("en-US"),
+      description: "Orders placed all-time",
+      icon: ShoppingBag,
+    },
+    {
+      label: "Awaiting fulfilment",
+      value: pendingOrderCount.toLocaleString("en-US"),
+      description: "Pending or processing",
+      icon: Clock,
+    },
+    {
+      label: "Total revenue",
+      value: formatCurrency(totalRevenue),
+      description: "Lifetime order value",
+      icon: DollarSign,
+    },
+  ] as const;
+
+  return (
+    <main className="pb-20">
+      <div className="max-w-frame mx-auto px-4 xl:px-0">
+        <header className="pt-8 pb-10 sm:pb-12">
+          <p className="text-sm font-medium uppercase tracking-[0.3em] text-black/60">
+            Admin overview
+          </p>
+          <h1 className="mt-4 text-3xl font-bold text-black sm:text-[40px]">
+            Welcome back, {user.fullName.split(" ")[0] ?? "Admin"}
+          </h1>
+          <p className="mt-3 max-w-2xl text-base text-black/60">
+            Quickly review how TSR Fashion is performing and jump into the tools
+            you use most to run the store.
+          </p>
+          <div className="mt-6 flex flex-col gap-3 sm:flex-row sm:items-center">
+            <Button asChild className="h-[48px] rounded-full bg-black px-6 text-sm font-semibold text-white hover:bg-black/90">
+              <Link href="/shop">View storefront</Link>
+            </Button>
+            <Button
+              asChild
+              variant="outline"
+              className="h-[48px] rounded-full border-black/15 bg-white px-6 text-sm font-semibold text-black hover:border-black"
+            >
+              <Link href="/profile">Manage account</Link>
+            </Button>
+          </div>
+        </header>
+
+        <section className="grid gap-6 lg:grid-cols-2 xl:grid-cols-4">
+          {stats.map((stat) => (
+            <div
+              key={stat.label}
+              className="flex flex-col justify-between gap-6 rounded-[28px] border border-black/10 bg-white p-6 shadow-[0_12px_40px_-20px_rgba(15,23,42,0.2)]"
+            >
+              <div className="flex items-start justify-between">
+                <div>
+                  <p className="text-sm font-medium text-black/50">{stat.label}</p>
+                  <p className="mt-3 text-3xl font-semibold text-black sm:text-[34px]">
+                    {stat.value}
+                  </p>
+                </div>
+                <span className="flex h-12 w-12 items-center justify-center rounded-2xl bg-black text-white">
+                  <stat.icon className="h-6 w-6" />
+                </span>
+              </div>
+              <p className="text-sm text-black/50">{stat.description}</p>
+            </div>
+          ))}
+        </section>
+
+        <section className="mt-8 grid gap-6 lg:grid-cols-[minmax(0,2fr)_minmax(0,3fr)]">
+          <div className="rounded-[28px] border border-black/10 bg-white p-6">
+            <div className="flex items-center justify-between">
+              <h2 className="text-lg font-semibold text-black">Latest order</h2>
+              <PackageSearch className="h-5 w-5 text-black/60" />
+            </div>
+            {latestOrder ? (
+              <dl className="mt-6 space-y-4 text-sm text-black/70">
+                <div className="flex items-center justify-between">
+                  <dt className="text-black/60">Order</dt>
+                  <dd className="font-semibold text-black">
+                    #{latestOrder.orderNumber}
+                  </dd>
+                </div>
+                <div className="flex items-center justify-between">
+                  <dt className="text-black/60">Customer</dt>
+                  <dd className="font-medium text-black">
+                    {latestOrder.shippingName}
+                  </dd>
+                </div>
+                <div className="flex items-center justify-between">
+                  <dt className="text-black/60">Placed</dt>
+                  <dd className="font-medium text-black">
+                    {formatDate(latestOrder.placedOn)}
+                  </dd>
+                </div>
+                <div className="flex items-center justify-between">
+                  <dt className="text-black/60">Status</dt>
+                  <dd className="rounded-full bg-black/5 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-black/70">
+                    {formatStatus(latestOrder.status)}
+                  </dd>
+                </div>
+                <div className="flex items-center justify-between border-t border-dashed border-black/10 pt-4">
+                  <dt className="text-black/60">Order total</dt>
+                  <dd className="text-base font-semibold text-black">
+                    {formatCurrency(latestOrder.totalAmount)}
+                  </dd>
+                </div>
+              </dl>
+            ) : (
+              <p className="mt-6 text-sm text-black/60">
+                There are no orders yet. Once customers start placing orders,
+                you&rsquo;ll see the most recent one here.
+              </p>
+            )}
+          </div>
+
+          <div className="rounded-[28px] border border-black/10 bg-white p-6">
+            <div className="flex items-center justify-between">
+              <h2 className="text-lg font-semibold text-black">Quick actions</h2>
+              <Clock className="h-5 w-5 text-black/60" />
+            </div>
+            <div className="mt-6 space-y-4">
+              <Button
+                asChild
+                className="h-[48px] w-full justify-between rounded-2xl bg-black px-4 text-sm font-semibold text-white hover:bg-black/90"
+              >
+                <Link href="/order-tracking">
+                  Review order tracking
+                  <span aria-hidden>&rarr;</span>
+                </Link>
+              </Button>
+              <Button
+                asChild
+                variant="outline"
+                className="h-[48px] w-full justify-between rounded-2xl border-black/15 bg-white px-4 text-sm font-semibold text-black hover:border-black"
+              >
+                <Link href="/support">
+                  View support inbox
+                  <span aria-hidden>&rarr;</span>
+                </Link>
+              </Button>
+            </div>
+            <p className="mt-5 text-xs text-black/50">
+              Need to perform something more advanced? You can always reach out
+              to the engineering team to extend the dashboard with additional
+              admin tools.
+            </p>
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -51,6 +51,7 @@ export async function POST(request: Request) {
         email: user.email,
         fullName: user.fullName,
         phone: user.phone,
+        role: user.role,
         createdAt: user.createdAt,
       },
     });

--- a/src/app/api/auth/me/route.ts
+++ b/src/app/api/auth/me/route.ts
@@ -15,6 +15,7 @@ export async function GET() {
       email: user.email,
       fullName: user.fullName,
       phone: user.phone,
+      role: user.role,
       createdAt: user.createdAt,
       updatedAt: user.updatedAt,
     },

--- a/src/app/api/auth/profile/route.ts
+++ b/src/app/api/auth/profile/route.ts
@@ -74,6 +74,7 @@ export async function PATCH(request: Request) {
       email: true,
       fullName: true,
       phone: true,
+      role: true,
       createdAt: true,
       updatedAt: true,
     },

--- a/src/app/api/auth/signup/route.ts
+++ b/src/app/api/auth/signup/route.ts
@@ -49,6 +49,7 @@ export async function POST(request: Request) {
         email: true,
         fullName: true,
         phone: true,
+        role: true,
         createdAt: true,
       },
     });

--- a/src/app/checkout/page.tsx
+++ b/src/app/checkout/page.tsx
@@ -114,6 +114,7 @@ type CurrentUser = {
   email: string;
   fullName: string;
   phone?: string | null;
+  role: "USER" | "ADMIN";
 };
 
 const getCartItemFinalPrice = (item: CartItem) => {
@@ -244,6 +245,7 @@ export default function CheckoutPage() {
               email: data.user.email,
               fullName: data.user.fullName,
               phone: data.user.phone ?? "",
+              role: data.user.role,
             })
           );
         }
@@ -374,6 +376,7 @@ export default function CheckoutPage() {
                 email: data.user.email,
                 fullName: data.user.fullName,
                 phone: data.user.phone ?? "",
+                role: data.user.role,
               })
             );
           }

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -70,6 +70,7 @@ export default function LoginPage() {
                 id: data.user.id,
                 email: data.user.email,
                 fullName: data.user.fullName,
+                role: data.user.role,
               })
             );
           }
@@ -101,7 +102,10 @@ export default function LoginPage() {
       });
 
       const data = (await response.json().catch(() => null)) as
-        | { message?: string; user?: { id: string; email: string; fullName: string } }
+        | {
+            message?: string;
+            user?: { id: string; email: string; fullName: string; role: "USER" | "ADMIN" };
+          }
         | null;
 
       if (!response.ok) {
@@ -117,6 +121,7 @@ export default function LoginPage() {
             id: data.user.id,
             email: data.user.email,
             fullName: data.user.fullName,
+            role: data.user.role,
           })
         );
       }

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -71,6 +71,7 @@ type CurrentUser = {
   email: string;
   fullName: string;
   phone?: string | null;
+  role: "USER" | "ADMIN";
   createdAt: string;
   updatedAt?: string;
 };
@@ -133,6 +134,7 @@ const ProfileLoginForm = ({
             email: data.user.email,
             fullName: data.user.fullName,
             phone: data.user.phone ?? "",
+            role: data.user.role,
           })
         );
         onLogin(data.user);
@@ -273,6 +275,14 @@ const ProfileSummary = ({
             </p>
             <p className="mt-1 text-base font-medium text-black">
               {user.phone?.trim() ?? "Add a phone number"}
+            </p>
+          </div>
+          <div>
+            <p className="text-xs uppercase tracking-wide text-black/50">
+              Account role
+            </p>
+            <p className="mt-1 text-base font-medium text-black">
+              {user.role === "ADMIN" ? "Administrator" : "Customer"}
             </p>
           </div>
         </div>
@@ -422,6 +432,7 @@ const AccountUpdateForm = ({
         headers: {
           "Content-Type": "application/json",
         },
+        credentials: "include",
         body: JSON.stringify(payload),
       });
 
@@ -661,6 +672,7 @@ export default function ProfilePage() {
         email: sessionUser.email,
         fullName: sessionUser.fullName,
         phone: sessionUser.phone ?? "",
+        role: sessionUser.role,
       })
     );
   }, []);
@@ -791,6 +803,14 @@ export default function ProfilePage() {
             this information current helps us speed up future checkouts.
           </p>
           <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-center">
+            {user?.role === "ADMIN" ? (
+              <Link
+                href="/admin"
+                className="inline-flex h-[48px] items-center justify-center rounded-full border border-black/15 px-6 text-sm font-medium text-black transition hover:border-black"
+              >
+                Open admin dashboard
+              </Link>
+            ) : null}
             <Link
               href="/order-tracking"
               className="inline-flex h-[48px] items-center justify-center rounded-full border border-black/15 px-6 text-sm font-medium text-black transition hover:border-black"

--- a/src/app/profile/update/page.tsx
+++ b/src/app/profile/update/page.tsx
@@ -60,6 +60,7 @@ type CurrentUser = {
   email: string;
   fullName: string;
   phone?: string | null;
+  role: "USER" | "ADMIN";
 };
 
 type AuthStatus = "loading" | "guest" | "authenticated";
@@ -133,6 +134,7 @@ export default function ProfileUpdatePage() {
               email: data.user.email,
               fullName: data.user.fullName,
               phone: data.user.phone ?? "",
+              role: data.user.role,
             })
           );
         }

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -92,7 +92,16 @@ export default function SignupPage() {
       const data = (await response
         .json()
         .catch(() => null)) as
-        | { message?: string; user?: { id: string; email: string; fullName: string; phone?: string | null } }
+        | {
+            message?: string;
+            user?: {
+              id: string;
+              email: string;
+              fullName: string;
+              phone?: string | null;
+              role: "USER" | "ADMIN";
+            };
+          }
         | null;
 
       if (!response.ok) {
@@ -108,6 +117,7 @@ export default function SignupPage() {
             email: data.user.email,
             fullName: data.user.fullName,
             phone: data.user.phone ?? "",
+            role: data.user.role,
           })
         );
       }

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -89,3 +89,17 @@ export const requireCurrentUser = async () => {
 
   return user;
 };
+
+export const requireAdminUser = async () => {
+  const maybeUser = await requireCurrentUser();
+
+  if (maybeUser instanceof NextResponse) {
+    return maybeUser;
+  }
+
+  if (maybeUser.role !== "ADMIN") {
+    return NextResponse.json({ message: "Forbidden" }, { status: 403 });
+  }
+
+  return maybeUser;
+};


### PR DESCRIPTION
## Summary
- add an admin role to the Prisma schema with a migration and seed script for a default administrator
- expose user roles across authentication APIs and client flows so admins can reach protected tools
- introduce a simple admin dashboard showing store metrics and quick actions using the shadcn UI kit

## Testing
- npm run lint
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d8e06ad1808322934d28b0af44c2a6